### PR TITLE
Inclusion #3: CA data time plots: regression and stripplot of time point distributions

### DIFF
--- a/mrsa_ca_rna/figures/figure05.py
+++ b/mrsa_ca_rna/figures/figure05.py
@@ -1,0 +1,106 @@
+"""Regressing against time"""
+
+import pandas as pd
+import seaborn as sns
+import numpy as np
+
+from mrsa_ca_rna.import_data import concat_datasets, ca_data_split
+from mrsa_ca_rna.pca import perform_PCA
+from mrsa_ca_rna.regression import perform_linear_regression, perform_elastic_regression
+from mrsa_ca_rna.figures.base import setupBase
+
+
+def figure05_setup(components: int = 60):
+    # for compatibility, I'm just going to remake the df from the adata object
+    data_df = concat_datasets(scale=True, tpm=True).to_df()
+    scores, _, _ = perform_PCA(data_df)
+    time_adata, _, _ = ca_data_split(scale=True, tpm=True)
+
+    time_meta = time_adata.obs.loc[:, ["subject_id", "time"]]
+    # time_meta = time_data.loc[:, ("meta", ["subject_id", "time"])]
+
+    time_scores: pd.DataFrame = pd.concat(
+        [time_meta, scores],
+        axis=1,
+        keys=["meta", "components"],
+        join="inner",
+    )
+
+    linear_scores = []
+    eNet_scores = []
+    for i in range(1, components + 1):
+        desired_components = pd.IndexSlice[
+            "components", time_scores["components"].columns[0:i]
+        ]
+        linear_performance, _ = perform_linear_regression(
+            time_scores.loc[:, desired_components], time_scores.loc[:, ("meta", "time")]
+        )
+        eNet_performance, eNet_model = perform_elastic_regression(
+            time_scores.loc[:, desired_components], time_scores.loc[:, ("meta", "time")]
+        )
+
+        linear_scores.append(linear_performance)
+        eNet_scores.append(eNet_performance)
+    linear_performance = pd.DataFrame(linear_scores, columns=["Nested Accuracy"])
+    eNet_performance = pd.DataFrame(eNet_scores, columns=["Nested Accuracy"])
+
+    time_components = time_scores.drop(columns=("meta", "subject_id"))
+    ordered_time: pd.DataFrame = time_components.sort_values(by=[("meta", "time")])
+
+    weighted_time = ordered_time.copy()
+    terminal_components = pd.IndexSlice[
+        "components", weighted_time["components"].columns[:components]
+    ]
+    for sample in weighted_time.index:
+        weighted_time.loc[sample, terminal_components] = (
+            ordered_time.loc[sample, terminal_components].values * eNet_model.coef_
+        )
+
+    return linear_performance, eNet_performance, weighted_time
+
+
+def genFig():
+    fig_size = (12, 4)
+    layout = {"ncols": 3, "nrows": 1}
+    ax, f, _ = setupBase(fig_size, layout)
+
+    components = 60
+
+    # runs = list(range(1))
+    # data_list = list()
+    # for run in runs:
+    #     data = figure05_setup(components=components)
+    #     data.rename(
+    #         columns={"Nested Accuracy": f"Nested Accuracy, run: {run+1}"},
+    #         inplace=True,
+    #     )
+    #     data_list.append(data)
+
+    linear_scores, eNet_scores, weighted_time = figure05_setup(components=components)
+    model_scores = {"linear": linear_scores, "eNet": eNet_scores}
+
+    for i, model in enumerate(model_scores):
+        model_scores[model].insert(
+            0, column="components", value=np.arange(1, components + 1)
+        )
+
+        a = sns.lineplot(
+            data=model_scores[model], x="components", y="Nested Accuracy", ax=ax[i]
+        )
+
+        a.set_xlabel("# of components")
+        a.set_ylabel("R2 Score")
+        a.set_title(
+            f"{model} regression on PCA data w.r.t. time\nNested cross validated"
+        )
+
+    a = sns.heatmap(
+        weighted_time["components"],
+        cmap="viridis",
+        center=0,
+        yticklabels=weighted_time[("meta", "time")],
+        ax=ax[2],
+    )
+    a.set_title("PCs weighted by eNet time regression coefficients")
+
+    return f

--- a/mrsa_ca_rna/figures/figure06.py
+++ b/mrsa_ca_rna/figures/figure06.py
@@ -1,0 +1,48 @@
+"""Stripplot of time points for patients to get a sense of how our time data is distributed."""
+
+from mrsa_ca_rna.import_data import ca_data_split
+from mrsa_ca_rna.figures.base import setupBase
+
+import seaborn as sns
+
+
+def figure06_setup():
+    ca_time_rna, _, _ = ca_data_split(scale=True, tpm=True)
+
+    pat_time_meta = ca_time_rna.obs.loc[:, ["subject_id", "time"]]
+    # pat_time_meta = ca_time_rna.loc[:, [("meta", "subject_id"), ("meta", "time")]]
+
+    return pat_time_meta
+
+
+def genFig():
+    fig_size = (6, 4)
+    layout = {"ncols": 1, "nrows": 2}
+    ax, f, _ = setupBase(fig_size, layout)
+
+    data = figure06_setup()
+
+    # cast time as int so stipplot infers properly, and order by subject_id to line up plots
+    data["time"] = data["time"].astype(int)
+    sorted_data = data.sort_values(by=["subject_id"])
+
+    a = sns.stripplot(
+        data=sorted_data, x="subject_id", y="time", ax=ax[0], jitter=False
+    )
+    a.set_title("Time points collected for each patient")
+    a.set_xlabel("Patient")
+    a.set_ylabel("Time points (days)")
+    a.tick_params(axis="x", rotation=45)
+
+    a = sns.barplot(
+        data=sorted_data.groupby("subject_id").count(),
+        x="subject_id",
+        y="time",
+        ax=ax[1],
+    )
+    a.set_title("Total time points associated with each patient")
+    a.set_xlabel("Patient")
+    a.set_ylabel("# of time points")
+    a.tick_params(axis="x", rotation=45)
+
+    return f


### PR DESCRIPTION
Includes figure05 and figure06. Linear regression on the CA dataset to predict time points (if the CA data itself can be used to "predict" the time it was taken) and a stipplot of the time data distribution to get a better view of the way to time data is distributed among patients.