### PR TITLE
pf2_factorization changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+wandb/
 
 # Translations
 *.mo
@@ -128,6 +129,9 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# vscode
+.vscode/
 
 # Pyre type checker
 .pyre/

--- a/mrsa_ca_rna/figures/figure10.py
+++ b/mrsa_ca_rna/figures/figure10.py
@@ -16,7 +16,7 @@ def figure10_setup():
     time_xr = prepare_data(time_data, expansion_dim="subject_id")
 
     # going above rank = 2 causes function failure
-    tensor_decomp, _ = perform_parafac2(time_xr, rank=3)
+    tensor_decomp, _, _ = perform_parafac2(time_xr, rank=2)
     time_factors = tensor_decomp[1]
 
     return time_factors

--- a/mrsa_ca_rna/figures/figure11.py
+++ b/mrsa_ca_rna/figures/figure11.py
@@ -36,11 +36,11 @@ def figure11_setup():
     r2x_t = []
 
     for rank_d in ranks_d:
-        _, rec_errors_d = perform_parafac2(disease_xr, rank=rank_d)
+        _, _, rec_errors_d = perform_parafac2(disease_xr, rank=rank_d)
         r2x_d.append(1 - min(rec_errors_d))
 
     for rank_t in ranks_t:
-        _, rec_errors_t = perform_parafac2(time_xr, rank=rank_t)
+        _, _, rec_errors_t = perform_parafac2(time_xr, rank=rank_t)
         r2x_t.append(1 - min(rec_errors_t))
 
     return r2x_d, r2x_t

--- a/mrsa_ca_rna/figures/figure11.py
+++ b/mrsa_ca_rna/figures/figure11.py
@@ -28,20 +28,19 @@ def figure11_setup():
     disease_xr = prepare_data(disease_data, expansion_dim="disease")
     time_xr = prepare_data(time_data, expansion_dim="subject_id")
 
-    # change ranks_d back to range(1, 11) when running the full dataset!
-    ranks_d = range(1, 21)
-    ranks_t = range(1, 21)
+    ranks_d = range(2, 10)
+    ranks_t = range(2, 10)
 
     r2x_d = []
     r2x_t = []
 
     for rank_d in ranks_d:
-        _, _, rec_errors_d = perform_parafac2(disease_xr, rank=rank_d)
-        r2x_d.append(1 - min(rec_errors_d))
+        _, _, rec_error_d = perform_parafac2(disease_xr, rank=rank_d)
+        r2x_d.append(1 - rec_error_d)
 
     for rank_t in ranks_t:
-        _, _, rec_errors_t = perform_parafac2(time_xr, rank=rank_t)
-        r2x_t.append(1 - min(rec_errors_t))
+        _, _, rec_error_t = perform_parafac2(time_xr, rank=rank_t)
+        r2x_t.append(1 - rec_error_t)
 
     return r2x_d, r2x_t
 

--- a/mrsa_ca_rna/figures/figure12.py
+++ b/mrsa_ca_rna/figures/figure12.py
@@ -19,7 +19,7 @@ def figure12_setup():
 
     disease_xr = prepare_data(disease_data, expansion_dim="disease")
 
-    tensor_decomp, recon_err = perform_parafac2(disease_xr, rank=50)
+    tensor_decomp, _, recon_err = perform_parafac2(disease_xr, rank=50)
     disease_factors = tensor_decomp[1]
     r2x = 1 - min(recon_err)
 

--- a/mrsa_ca_rna/figures/figure12.py
+++ b/mrsa_ca_rna/figures/figure12.py
@@ -19,9 +19,9 @@ def figure12_setup():
 
     disease_xr = prepare_data(disease_data, expansion_dim="disease")
 
-    tensor_decomp, _, recon_err = perform_parafac2(disease_xr, rank=50)
+    tensor_decomp, _, recon_err = perform_parafac2(disease_xr, rank=10)
     disease_factors = tensor_decomp[1]
-    r2x = 1 - min(recon_err)
+    r2x = 1 - recon_err
 
     return disease_factors, r2x, disease_data
 

--- a/mrsa_ca_rna/utils.py
+++ b/mrsa_ca_rna/utils.py
@@ -223,6 +223,7 @@ def concat_datasets(
 
     return whole_ad
 
+
 def check_sparsity(array: np.ndarray, threshold: float = 1e-4) -> float:
     """Check the sparsity of a numpy array
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,16 +7,20 @@ readme = "README.md"
 requires-python = ">=3.11"
 
 dependencies = [
-"scikit-learn>=1.5.0",
-"matplotlib>=3.9.0",
-"ipympl>=0.9.4",
-"pandas>=2.2.2",
-"seaborn>=0.13.2",
-"svgutils>=0.3.4",
-"anndata>=0.10.8",
-"xarray>=2024.7.0",
-"cupy-cuda12x>=13.3.0",
-"tensorly @ git+https://github.com/tensorly/tensorly.git@041cd699d08ae846acbc4e921e0f490e39269760"]
+    "scikit-learn>=1.5.0",
+    "matplotlib>=3.9.0",
+    "ipympl>=0.9.4",
+    "pandas>=2.2.2",
+    "seaborn>=0.13.2",
+    "svgutils>=0.3.4",
+    "anndata>=0.10.8",
+    "xarray>=2024.7.0",
+    "cupy-cuda12x>=13.3.0",
+    "tensorly @ git+https://github.com/tensorly/tensorly.git@041cd699d08ae846acbc4e921e0f490e39269760",
+    "matcouply>=0.1.6",
+    "wandb>=0.19.6",
+    "pacmap>=0.8.0",
+]
 
 [project.scripts]                                                        
 fbuild = "mrsa_ca_rna.figures.base:genFigure"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -12,10 +12,21 @@
 -e file:.
 anndata==0.10.9
     # via mrsa-ca-rna
+annotated-types==0.7.0
+    # via pydantic
+annoy==1.17.3
+    # via pacmap
 array-api-compat==1.8
     # via anndata
 asttokens==2.4.1
     # via stack-data
+certifi==2025.1.31
+    # via requests
+    # via sentry-sdk
+charset-normalizer==3.4.1
+    # via requests
+click==8.1.8
+    # via wandb
 comm==0.2.2
     # via ipywidgets
 contourpy==1.3.0
@@ -28,14 +39,22 @@ cycler==0.12.1
     # via matplotlib
 decorator==5.1.1
     # via ipython
+docker-pycreds==0.4.0
+    # via wandb
 executing==2.1.0
     # via stack-data
 fastrlock==0.8.2
     # via cupy-cuda12x
 fonttools==4.54.1
     # via matplotlib
+gitdb==4.0.12
+    # via gitpython
+gitpython==3.1.44
+    # via wandb
 h5py==3.12.0
     # via anndata
+idna==3.10
+    # via requests
 iniconfig==2.0.0
     # via pytest
 ipympl==0.9.4
@@ -55,8 +74,12 @@ jupyterlab-widgets==3.0.13
     # via ipywidgets
 kiwisolver==1.4.7
     # via matplotlib
+llvmlite==0.44.0
+    # via numba
 lxml==5.3.0
     # via svgutils
+matcouply==0.1.6
+    # via mrsa-ca-rna
 matplotlib==3.9.2
     # via ipympl
     # via mrsa-ca-rna
@@ -67,13 +90,18 @@ natsort==8.4.0
     # via anndata
 nodeenv==1.9.1
     # via pyright
+numba==0.61.0
+    # via pacmap
 numpy==2.1.1
     # via anndata
     # via contourpy
     # via cupy-cuda12x
     # via h5py
     # via ipympl
+    # via matcouply
     # via matplotlib
+    # via numba
+    # via pacmap
     # via pandas
     # via scikit-learn
     # via scipy
@@ -85,6 +113,8 @@ packaging==24.1
     # via matplotlib
     # via pytest
     # via xarray
+pacmap==0.8.0
+    # via mrsa-ca-rna
 pandas==2.2.3
     # via anndata
     # via mrsa-ca-rna
@@ -97,14 +127,24 @@ pexpect==4.9.0
 pillow==10.4.0
     # via ipympl
     # via matplotlib
+platformdirs==4.3.6
+    # via wandb
 pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.48
     # via ipython
+protobuf==5.29.3
+    # via wandb
+psutil==7.0.0
+    # via wandb
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
+pydantic==2.10.6
+    # via wandb
+pydantic-core==2.27.2
+    # via pydantic
 pygments==2.18.0
     # via ipython
 pyparsing==3.1.4
@@ -118,22 +158,38 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.2
     # via pandas
+pyyaml==6.0.2
+    # via wandb
+requests==2.32.3
+    # via wandb
 scikit-learn==1.5.2
     # via mrsa-ca-rna
+    # via pacmap
 scipy==1.14.1
     # via anndata
+    # via matcouply
     # via scikit-learn
     # via tensorly
 seaborn==0.13.2
     # via mrsa-ca-rna
+sentry-sdk==2.21.0
+    # via wandb
+setproctitle==1.3.4
+    # via wandb
+setuptools==75.8.0
+    # via wandb
 six==1.16.0
     # via asttokens
+    # via docker-pycreds
     # via python-dateutil
+smmap==5.0.2
+    # via gitdb
 stack-data==0.6.3
     # via ipython
 svgutils==0.3.4
     # via mrsa-ca-rna
 tensorly @ git+https://github.com/tensorly/tensorly.git@041cd699d08ae846acbc4e921e0f490e39269760
+    # via matcouply
     # via mrsa-ca-rna
 threadpoolctl==3.5.0
     # via scikit-learn
@@ -145,9 +201,17 @@ traitlets==5.14.3
     # via matplotlib-inline
 typing-extensions==4.12.2
     # via ipython
+    # via pydantic
+    # via pydantic-core
     # via pyright
+    # via wandb
 tzdata==2024.2
     # via pandas
+urllib3==2.3.0
+    # via requests
+    # via sentry-sdk
+wandb==0.19.6
+    # via mrsa-ca-rna
 wcwidth==0.2.13
     # via prompt-toolkit
 widgetsnbextension==4.0.13

--- a/requirements.lock
+++ b/requirements.lock
@@ -12,10 +12,21 @@
 -e file:.
 anndata==0.10.9
     # via mrsa-ca-rna
+annotated-types==0.7.0
+    # via pydantic
+annoy==1.17.3
+    # via pacmap
 array-api-compat==1.8
     # via anndata
 asttokens==2.4.1
     # via stack-data
+certifi==2025.1.31
+    # via requests
+    # via sentry-sdk
+charset-normalizer==3.4.1
+    # via requests
+click==8.1.8
+    # via wandb
 comm==0.2.2
     # via ipywidgets
 contourpy==1.3.0
@@ -26,14 +37,22 @@ cycler==0.12.1
     # via matplotlib
 decorator==5.1.1
     # via ipython
+docker-pycreds==0.4.0
+    # via wandb
 executing==2.1.0
     # via stack-data
 fastrlock==0.8.2
     # via cupy-cuda12x
 fonttools==4.54.1
     # via matplotlib
+gitdb==4.0.12
+    # via gitpython
+gitpython==3.1.44
+    # via wandb
 h5py==3.12.0
     # via anndata
+idna==3.10
+    # via requests
 ipympl==0.9.4
     # via mrsa-ca-rna
 ipython==8.27.0
@@ -51,8 +70,12 @@ jupyterlab-widgets==3.0.13
     # via ipywidgets
 kiwisolver==1.4.7
     # via matplotlib
+llvmlite==0.44.0
+    # via numba
 lxml==5.3.0
     # via svgutils
+matcouply==0.1.6
+    # via mrsa-ca-rna
 matplotlib==3.9.2
     # via ipympl
     # via mrsa-ca-rna
@@ -61,13 +84,18 @@ matplotlib-inline==0.1.7
     # via ipython
 natsort==8.4.0
     # via anndata
+numba==0.61.0
+    # via pacmap
 numpy==2.1.1
     # via anndata
     # via contourpy
     # via cupy-cuda12x
     # via h5py
     # via ipympl
+    # via matcouply
     # via matplotlib
+    # via numba
+    # via pacmap
     # via pandas
     # via scikit-learn
     # via scipy
@@ -78,6 +106,8 @@ packaging==24.1
     # via anndata
     # via matplotlib
     # via xarray
+pacmap==0.8.0
+    # via mrsa-ca-rna
 pandas==2.2.3
     # via anndata
     # via mrsa-ca-rna
@@ -90,12 +120,22 @@ pexpect==4.9.0
 pillow==10.4.0
     # via ipympl
     # via matplotlib
+platformdirs==4.3.6
+    # via wandb
 prompt-toolkit==3.0.48
     # via ipython
+protobuf==5.29.3
+    # via wandb
+psutil==7.0.0
+    # via wandb
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.3
     # via stack-data
+pydantic==2.10.6
+    # via wandb
+pydantic-core==2.27.2
+    # via pydantic
 pygments==2.18.0
     # via ipython
 pyparsing==3.1.4
@@ -105,22 +145,38 @@ python-dateutil==2.9.0.post0
     # via pandas
 pytz==2024.2
     # via pandas
+pyyaml==6.0.2
+    # via wandb
+requests==2.32.3
+    # via wandb
 scikit-learn==1.5.2
     # via mrsa-ca-rna
+    # via pacmap
 scipy==1.14.1
     # via anndata
+    # via matcouply
     # via scikit-learn
     # via tensorly
 seaborn==0.13.2
     # via mrsa-ca-rna
+sentry-sdk==2.21.0
+    # via wandb
+setproctitle==1.3.4
+    # via wandb
+setuptools==75.8.0
+    # via wandb
 six==1.16.0
     # via asttokens
+    # via docker-pycreds
     # via python-dateutil
+smmap==5.0.2
+    # via gitdb
 stack-data==0.6.3
     # via ipython
 svgutils==0.3.4
     # via mrsa-ca-rna
 tensorly @ git+https://github.com/tensorly/tensorly.git@041cd699d08ae846acbc4e921e0f490e39269760
+    # via matcouply
     # via mrsa-ca-rna
 threadpoolctl==3.5.0
     # via scikit-learn
@@ -132,8 +188,16 @@ traitlets==5.14.3
     # via matplotlib-inline
 typing-extensions==4.12.2
     # via ipython
+    # via pydantic
+    # via pydantic-core
+    # via wandb
 tzdata==2024.2
     # via pandas
+urllib3==2.3.0
+    # via requests
+    # via sentry-sdk
+wandb==0.19.6
+    # via mrsa-ca-rna
 wcwidth==0.2.13
     # via prompt-toolkit
 widgetsnbextension==4.0.13


### PR DESCRIPTION
Changes:
  - utils.py
    - moved gene filtering to be after TPM in `concat_datasets`
    - added `check_sparsity()` function
  - factorization.py
    - switched to matcouply `parafac_aoadmm()` from tnesorly's parafac2 decomposition
    - added `normalize_factors()` to recover tensorly's normalization
  - gitignore
    - prepared for wandb logging from Weights and Biases