### PR TITLE
Pca variability

### DIFF
--- a/mrsa_ca_rna/figures/figure_pca_component_variability.py
+++ b/mrsa_ca_rna/figures/figure_pca_component_variability.py
@@ -18,11 +18,9 @@ def matrix_cosines(a: pd.DataFrame, b: pd.DataFrame) -> np.ndarray:
     which are organized as dataframes.
     """
     return np.array(
-        [
-            spatial.distance.cosine(a.iloc[:, i], b.iloc[:, i])
-            for i in range(a.shape[1])
-        ]
+        [spatial.distance.cosine(a.iloc[:, i], b.iloc[:, i]) for i in range(a.shape[1])]
     )
+
 
 def figure_setup():
     # import and convert the data to pandas for resample
@@ -31,14 +29,16 @@ def figure_setup():
     # start with a pca decomposition of the true data
     _, loadings_true, _ = perform_pca(mrsa_ca, components=70)
 
-
-    # resample the data 
+    # resample the data
     n_resamples = 100
-    resampled_data = [resample(mrsa_ca, replace=True) for _ in range(n_resamples)]
+    resampled_data: list[pd.DataFrame] = [
+        resample(mrsa_ca, replace=True)
+        for _ in range(n_resamples)  # type: ignore
+    ]
 
     # set up dataframes
-    pc_index = [f"{i}" for i in range(1, 71)]
-    pc_columns = [f"Resample {i+1}" for i in range(n_resamples)]
+    pc_index = pd.Index([f"{i}" for i in range(1, 71)])
+    pc_columns = pd.Index([f"Resample {i+1}" for i in range(n_resamples)])
 
     pca_singular_values = pd.DataFrame(
         np.zeros((70, n_resamples)), columns=pc_columns, index=pc_index

--- a/mrsa_ca_rna/figures/figure_pca_component_variability.py
+++ b/mrsa_ca_rna/figures/figure_pca_component_variability.py
@@ -12,9 +12,10 @@ from mrsa_ca_rna.pca import perform_pca
 from mrsa_ca_rna.utils import concat_datasets
 
 
-def matrix_cosines(a, b):
+def matrix_cosines(a: pd.DataFrame, b: pd.DataFrame) -> np.ndarray:
     """
     Compute the column-wsie cosine similarity between two matrices
+    which are organized as dataframes.
     """
     return np.array(
         [
@@ -28,7 +29,7 @@ def figure_setup():
     mrsa_ca = concat_datasets(["mrsa", "ca"], scale=True).to_df()
 
     # start with a pca decomposition of the true data
-    scores_true, _, _ = perform_pca(mrsa_ca, components=70)
+    _, loadings_true, _ = perform_pca(mrsa_ca, components=70)
 
 
     # resample the data 
@@ -49,9 +50,9 @@ def figure_setup():
     # perform PCA on each resampled dataset, storing the metrics of interest
     # into the dataframes
     for i, data in enumerate(resampled_data):
-        scores, _, pca = perform_pca(data, components=70)
+        _, loadings, pca = perform_pca(data, components=70)
         pca_singular_values.iloc[:, i] = pca.singular_values_
-        pca_diff.iloc[:, i] = matrix_cosines(scores_true, scores)
+        pca_diff.iloc[:, i] = matrix_cosines(loadings_true.T, loadings.T)
 
     return pca_singular_values, pca_diff
 

--- a/mrsa_ca_rna/figures/figure_pca_component_variability.py
+++ b/mrsa_ca_rna/figures/figure_pca_component_variability.py
@@ -1,0 +1,29 @@
+"""This file will plot the norms of the PCA components for the MRSA CA RNA data to
+assess the variability of the components across runs with resampling."""
+
+import numpy as np
+import pandas as pd
+
+from sklearn.utils import resample
+
+from mrsa_ca_rna.pca import perform_pca
+from mrsa_ca_rna.utils import concat_datasets
+
+
+def figure_setup():
+
+    mrsa_ca = concat_datasets(["mrsa", "ca"], scale=True)
+
+    # resample the data 1000 times
+    resampled_data = []
+    for _ in range(1000):
+        resampled_data.append(resample(mrsa_ca, replace=True))
+
+    # for each resampled dataset, perform PCA and store the norms of the components
+    pca_norms = pd.DataFrame(index=[f"PC{i}" for i in range(1, 71)])
+    for i, data in enumerate(resampled_data):
+        _, _, pca = perform_pca(data, n_components=70)
+        pca_norms[f"Resample {i+1}"] = (np.linalg.norm(pca.components_, axis=1))
+        
+    return pca_norms
+figure_setup()

--- a/mrsa_ca_rna/figures/figure_pca_component_variability.py
+++ b/mrsa_ca_rna/figures/figure_pca_component_variability.py
@@ -3,27 +3,86 @@ assess the variability of the components across runs with resampling."""
 
 import numpy as np
 import pandas as pd
-
+import seaborn as sns
+from scipy import spatial
 from sklearn.utils import resample
 
+from mrsa_ca_rna.figures.base import setupBase
 from mrsa_ca_rna.pca import perform_pca
 from mrsa_ca_rna.utils import concat_datasets
 
 
+def matrix_cosines(a, b):
+    """
+    Compute the column-wsie cosine similarity between two matrices
+    """
+    return np.array(
+        [
+            spatial.distance.cosine(a.iloc[:, i], b.iloc[:, i])
+            for i in range(a.shape[1])
+        ]
+    )
+
 def figure_setup():
+    # import and convert the data to pandas for resample
+    mrsa_ca = concat_datasets(["mrsa", "ca"], scale=True).to_df()
 
-    mrsa_ca = concat_datasets(["mrsa", "ca"], scale=True)
+    # start with a pca decomposition of the true data
+    scores_true, _, _ = perform_pca(mrsa_ca, components=70)
 
-    # resample the data 1000 times
-    resampled_data = []
-    for _ in range(1000):
-        resampled_data.append(resample(mrsa_ca, replace=True))
 
-    # for each resampled dataset, perform PCA and store the norms of the components
-    pca_norms = pd.DataFrame(index=[f"PC{i}" for i in range(1, 71)])
+    # resample the data 
+    n_resamples = 100
+    resampled_data = [resample(mrsa_ca, replace=True) for _ in range(n_resamples)]
+
+    # set up dataframes
+    pc_index = [f"{i}" for i in range(1, 71)]
+    pc_columns = [f"Resample {i+1}" for i in range(n_resamples)]
+
+    pca_singular_values = pd.DataFrame(
+        np.zeros((70, n_resamples)), columns=pc_columns, index=pc_index
+    )
+    pca_diff = pd.DataFrame(
+        np.zeros((70, n_resamples)), columns=pc_columns, index=pc_index
+    )
+
+    # perform PCA on each resampled dataset, storing the metrics of interest
+    # into the dataframes
     for i, data in enumerate(resampled_data):
-        _, _, pca = perform_pca(data, n_components=70)
-        pca_norms[f"Resample {i+1}"] = (np.linalg.norm(pca.components_, axis=1))
-        
-    return pca_norms
-figure_setup()
+        scores, _, pca = perform_pca(data, components=70)
+        pca_singular_values.iloc[:, i] = pca.singular_values_
+        pca_diff.iloc[:, i] = matrix_cosines(scores_true, scores)
+
+    return pca_singular_values, pca_diff
+
+
+def genFig():
+    fig_size = (12, 8)
+    layout = {"ncols": 1, "nrows": 2}
+    ax, f, _ = setupBase(fig_size, layout)
+
+    pca_singular_values, pca_diff = figure_setup()
+
+    # convert to long form for plotting
+
+    pca_singular_values = pca_singular_values.reset_index(names=["Component"]).melt(
+        id_vars="Component", var_name="Resample", value_name="Singular Values"
+    )
+
+    pca_diff = pca_diff.reset_index(names=["Component"]).melt(
+        id_vars="Component", var_name="Resample", value_name="Cosine Distance"
+    )
+
+    a = sns.boxplot(
+        data=pca_singular_values, x="Component", y="Singular Values", ax=ax[0]
+    )
+    a.set_xlabel("PCA Component")
+    a.set_ylabel("Singular values")
+    a.set_title("Singular values of PCA Components across resampling")
+
+    a = sns.boxplot(data=pca_diff, x="Component", y="Cosine Distance", ax=ax[1])
+    a.set_xlabel("PCA Component")
+    a.set_ylabel("Cosine Distance")
+    a.set_title("Cosine Distance of PCA Components across resampling")
+
+    return f


### PR DESCRIPTION
Added `figure_pca_component_variability.py` to asses the differences in PCs between resampled pca decompositions.

Norms are decreasing in size, as expected and experience little variability.

Cosine differences are calculated from the "true" PCA, using the non-resampled data. In other words, each loadings matrix resulting from a PCA decomposition of resampled data is compared to the loadings matrix of a PCA decomposition of the true, non-resampled dataset.