### PR TITLE
GSEApy for ranked gene plots

### DIFF
--- a/mrsa_ca_rna/gsea.py
+++ b/mrsa_ca_rna/gsea.py
@@ -1,0 +1,93 @@
+import anndata as ad
+import gseapy as gp
+import pandas as pd
+from gseapy.plot import dotplot, gseaplot2
+
+
+def gsea_analysis_per_cmp(
+    X: ad.AnnData,
+    cmp: int,
+    term_ranks=5,
+    gene_set="GO_Biological_Process_2023",
+    figsize=(6, 4),
+    out_dir=None,
+):
+    """Performs a preranked GSEA analysis on a component of a tensor factorization.
+
+    Parameters
+    ----------
+    X : ad.AnnData
+        Pre-factored AnnData object with the component ranks in varm["Pf2_C"]
+    cmp : int
+        Component to analyze
+    term_ranks : int, optional
+        Number of GO terms to include, by default 5
+    gene_set : str, optional
+        Gene set to use as background, by default "GO_Biological_Process_2023"
+    figsize : tuple[int, int], optional
+        Size of figure in inches_tall x inches_wide, by default (6, 4)
+    out_dir : str, optional
+        Output directory for figures, by default None
+
+    Returns
+    -------
+    tuple[plt.Figure, plt.Figure]
+        gsea plot and dotplot figures (do not play well with DIY plotting)
+    """
+    term_ranks = slice(0, 5)
+
+    # make a two column dataframe for prerank
+    df = pd.DataFrame([])
+    df["Gene"] = X.var.index
+    df["Rank"] = X.varm["Pf2_C"][:, cmp - 1]  # type: ignore
+    df = df.sort_values("Rank", ascending=False).reset_index(drop=True)
+
+    # run the analysis and extract the results
+    pre_res = gp.prerank(rnk=df, gene_sets=gene_set, seed=0)
+
+    # check if the analysis ran successfully
+    assert isinstance(pre_res.res2d, pd.DataFrame), "GSEA analysis failed to run"
+    assert isinstance(pre_res.ranking, pd.Series), "GSEA analysis failed to run"
+
+    # collect the results
+    terms = pre_res.res2d.Term[term_ranks]
+    hits = [pre_res.results[t]["hits"] for t in terms]
+    runes = [pre_res.results[t]["RES"] for t in terms]
+
+    # Generate titles with component info
+    dotplot_title = f"Component {cmp} Dotplot"
+
+    gsea_ofname = out_dir + f"gsea_{cmp}.svg" if out_dir is not None else None
+    dotplot_ofname = out_dir + f"dotplot_{cmp}.svg" if out_dir is not None else None
+
+    fig_g = gseaplot2(
+        terms=terms,
+        RESs=runes,
+        hits=hits,
+        rank_metric=pre_res.ranking.to_list(),
+        figsize=figsize,
+        ofname=gsea_ofname,
+    )
+
+    # dotplot will fail if there are no genes within the cutoff but we want it anyway
+    try:
+        fig_d = dotplot(
+            pre_res.res2d,
+            column="FDR q-val",
+            title=dotplot_title,
+            cmap="viridis",
+            ofname=dotplot_ofname,
+        )
+    except ValueError:
+        # make a dotplot with no cutoff with title indicating it failed
+        print("Dotplot failed to generate. No genes within cutoff.")
+        fig_d = dotplot(
+            pre_res.res2d,
+            column="FDR q-val",
+            title="None w/in cutoff, showing all",
+            cutoff=1,
+            cmap="viridis",
+            ofname=dotplot_ofname,
+        )
+
+    return fig_g, fig_d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "tlviz>=0.1.1",
     "tensorly>=0.9.0",
     "h5py>=3.13.0",
+    "gseapy>=1.1.8",
 ]
 
 [project.scripts]                                                        

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -50,6 +50,8 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.44
     # via wandb
+gseapy==1.1.8
+    # via mrsa-ca-rna
 h5py==3.13.0
     # via anndata
     # via mrsa-ca-rna
@@ -75,6 +77,7 @@ jupyterlab-widgets==3.0.13
 kiwisolver==1.4.7
     # via matplotlib
 matplotlib==3.10.3
+    # via gseapy
     # via ipympl
     # via mrsa-ca-rna
     # via seaborn
@@ -89,6 +92,7 @@ numpy==2.1.1
     # via anndata
     # via contourpy
     # via cupy-cuda12x
+    # via gseapy
     # via h5py
     # via ipympl
     # via matplotlib
@@ -110,6 +114,7 @@ packaging==24.1
     # via xarray
 pandas==2.2.3
     # via anndata
+    # via gseapy
     # via mrsa-ca-rna
     # via seaborn
     # via statsmodels
@@ -160,6 +165,7 @@ pytz==2024.2
 pyyaml==6.0.2
     # via wandb
 requests==2.32.3
+    # via gseapy
     # via tlviz
     # via wandb
 scikit-learn==1.6.1
@@ -167,6 +173,7 @@ scikit-learn==1.6.1
     # via parafac2
 scipy==1.15.2
     # via anndata
+    # via gseapy
     # via parafac2
     # via scikit-learn
     # via statsmodels

--- a/requirements.lock
+++ b/requirements.lock
@@ -48,6 +48,8 @@ gitdb==4.0.12
     # via gitpython
 gitpython==3.1.44
     # via wandb
+gseapy==1.1.8
+    # via mrsa-ca-rna
 h5py==3.13.0
     # via anndata
     # via mrsa-ca-rna
@@ -71,6 +73,7 @@ jupyterlab-widgets==3.0.13
 kiwisolver==1.4.7
     # via matplotlib
 matplotlib==3.10.3
+    # via gseapy
     # via ipympl
     # via mrsa-ca-rna
     # via seaborn
@@ -83,6 +86,7 @@ numpy==2.1.1
     # via anndata
     # via contourpy
     # via cupy-cuda12x
+    # via gseapy
     # via h5py
     # via ipympl
     # via matplotlib
@@ -103,6 +107,7 @@ packaging==24.1
     # via xarray
 pandas==2.2.3
     # via anndata
+    # via gseapy
     # via mrsa-ca-rna
     # via seaborn
     # via statsmodels
@@ -147,6 +152,7 @@ pytz==2024.2
 pyyaml==6.0.2
     # via wandb
 requests==2.32.3
+    # via gseapy
     # via tlviz
     # via wandb
 scikit-learn==1.6.1
@@ -154,6 +160,7 @@ scikit-learn==1.6.1
     # via parafac2
 scipy==1.15.2
     # via anndata
+    # via gseapy
     # via parafac2
     # via scikit-learn
     # via statsmodels


### PR DESCRIPTION
## Additions:
gsea.py to plot pathway terms with ranked genes
 - Sets up ranked gene association plotting for use with Pf2 factorization

## To-Do:
Modify the base plotting functions to accept any array of samples x genes
 - Will add lots of flexibility for quickly performing large-scale analysis of gene matrices for biological associations

Figure out a way to plot multiple components on a grid
 - gseapy package very strict and does not play well with our base figure making
 - plotting multiple columns of ranked genes would be very convenient for larger scale analysis